### PR TITLE
Revert "fix(deps): update react monorepo to v19 (major)"

### DIFF
--- a/patterns/package.json
+++ b/patterns/package.json
@@ -22,8 +22,8 @@
     "clsx": "^2.1.1",
     "docusaurus-lunr-search": "^3.4.0",
     "prism-react-renderer": "^2.3.1",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.4.0",


### PR DESCRIPTION
Reverts bcgov/nr-architecture-patterns-library#65

Need to revert as renovate does not care for failed builds