### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -14,6 +14,9 @@ on:
 
 jobs:
   crud-confluenc:
+    permissions:
+      contents: write
+      pull-requests: write
     name: Get and update contents from confluence
     runs-on: ubuntu-24.04
     defaults:


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/nr-architecture-patterns-library/security/code-scanning/1](https://github.com/bcgov/nr-architecture-patterns-library/security/code-scanning/1)

To fix the problem, add a `permissions` block at the job level for `crud-confluenc` in `.github/workflows/schedule.yml`. Because the job performs git operations and opens a pull request, the minimal required permissions are `contents: write` and `pull-requests: write`. You should add the following block:

```yaml
permissions:
  contents: write
  pull-requests: write
```

Directly below the job definition (`crud-confluenc:`), insert the `permissions` key alongside `name`, `runs-on`, etc. This restricts the `GITHUB_TOKEN` to just those scopes needed. No imports or definitions are otherwise required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
